### PR TITLE
#13 Change Project ID to be an integer

### DIFF
--- a/skytap/credentials.go
+++ b/skytap/credentials.go
@@ -27,25 +27,6 @@ func NewNoOpCredentials() *NoOpCredentials {
 	return &NoOpCredentials{}
 }
 
-// PasswordCredentials describes the username password data
-type PasswordCredentials struct {
-	Username string
-	Password string
-}
-
-// Retrieve the username password data
-func (c *PasswordCredentials) Retrieve(ctx context.Context) (string, error) {
-	return buildBasicAuth(c.Username, c.Password), nil
-}
-
-// NewPasswordCredentials create a new username and password credentials instance
-func NewPasswordCredentials(username, password string) *PasswordCredentials {
-	return &PasswordCredentials{
-		Username: username,
-		Password: password,
-	}
-}
-
 // APITokenCredentials is ued when the credentials used are the username and api token data
 type APITokenCredentials struct {
 	Username string

--- a/skytap/credentials_test.go
+++ b/skytap/credentials_test.go
@@ -16,22 +16,6 @@ func TestNoOpCredentials(t *testing.T) {
 	assert.Equal(t, "", result)
 }
 
-func TestPasswordCredentials(t *testing.T) {
-	username := "user"
-	password := "password"
-	header := "Basic dXNlcjpwYXNzd29yZA=="
-
-	cred := NewPasswordCredentials(username, password)
-
-	assert.Equal(t, username, cred.Username)
-	assert.Equal(t, password, cred.Password)
-
-	result, err := cred.Retrieve(context.Background())
-
-	assert.NoError(t, err)
-	assert.Equal(t, header, result)
-}
-
 func TestApiTokenCredentials(t *testing.T) {
 	username := "user"
 	token := "token"

--- a/skytap/environment.go
+++ b/skytap/environment.go
@@ -376,7 +376,7 @@ type EnvironmentListResult struct {
 // CreateEnvironmentRequest describes the update the environment data
 type CreateEnvironmentRequest struct {
 	TemplateID      *string `json:"template_id,omitempty"`
-	ProjectID       *string `json:"project_id,omitempty"`
+	ProjectID       *int    `json:"project_id,omitempty"`
 	Name            *string `json:"name,omitempty"`
 	Description     *string `json:"description,omitempty"`
 	Owner           *string `json:"owner,omitempty"`

--- a/skytap/environment_test.go
+++ b/skytap/environment_test.go
@@ -370,7 +370,7 @@ func TestCreateEnvironment(t *testing.T) {
 			}
 			body, err := ioutil.ReadAll(req.Body)
 			assert.Nil(t, err)
-			assert.JSONEq(t, fmt.Sprintf(`{"template_id":%q, "description":"test environment"}`, "12345"), string(body))
+			assert.JSONEq(t, fmt.Sprintf(`{"template_id":%q, "project_id":%d, "description":"test environment"}`, "12345", 12345), string(body))
 			io.WriteString(rw, `{"id": "456"}`)
 			createPhase = false
 		} else {
@@ -390,6 +390,7 @@ func TestCreateEnvironment(t *testing.T) {
 
 	opts := &CreateEnvironmentRequest{
 		TemplateID:  strToPtr("12345"),
+		ProjectID:   intToPtr(12345),
 		Description: strToPtr("test environment"),
 	}
 

--- a/skytap/project.go
+++ b/skytap/project.go
@@ -14,10 +14,10 @@ const (
 // ProjectsService is the contract for the services provided on the Skytap Project resource
 type ProjectsService interface {
 	List(ctx context.Context) (*ProjectListResult, error)
-	Get(ctx context.Context, id string) (*Project, error)
+	Get(ctx context.Context, id int) (*Project, error)
 	Create(ctx context.Context, project *Project) (*Project, error)
-	Update(ctx context.Context, id string, project *Project) (*Project, error)
-	Delete(ctx context.Context, id string) error
+	Update(ctx context.Context, id int, project *Project) (*Project, error)
+	Delete(ctx context.Context, id int) error
 }
 
 // ProjectsServiceClient is the ProjectsService implementation
@@ -27,7 +27,7 @@ type ProjectsServiceClient struct {
 
 // Project resource struct definitions
 type Project struct {
-	ID                 *string      `json:"id,omitempty"`
+	ID                 *int         `json:"id,omitempty"`
 	Name               *string      `json:"name,omitempty"`
 	Summary            *string      `json:"summary,omitempty"`
 	AutoAddRoleName    *ProjectRole `json:"auto_add_role_name,omitempty"`
@@ -72,8 +72,8 @@ func (s *ProjectsServiceClient) List(ctx context.Context) (*ProjectListResult, e
 }
 
 // Get a project
-func (s *ProjectsServiceClient) Get(ctx context.Context, id string) (*Project, error) {
-	path := fmt.Sprintf("%s/%s", projectsBasePath, id)
+func (s *ProjectsServiceClient) Get(ctx context.Context, id int) (*Project, error) {
+	path := fmt.Sprintf("%s/%d", projectsBasePath, id)
 
 	req, err := s.client.newRequest(ctx, "GET", path, nil)
 	if err != nil {
@@ -114,8 +114,8 @@ func (s *ProjectsServiceClient) Create(ctx context.Context, project *Project) (*
 }
 
 // Update a project
-func (s *ProjectsServiceClient) Update(ctx context.Context, id string, project *Project) (*Project, error) {
-	path := fmt.Sprintf("%s/%s", projectsLegacyBasePath, id)
+func (s *ProjectsServiceClient) Update(ctx context.Context, id int, project *Project) (*Project, error) {
+	path := fmt.Sprintf("%s/%d", projectsLegacyBasePath, id)
 
 	req, err := s.client.newRequest(ctx, "PUT", path, project)
 	if err != nil {
@@ -132,8 +132,8 @@ func (s *ProjectsServiceClient) Update(ctx context.Context, id string, project *
 }
 
 // Delete a project
-func (s *ProjectsServiceClient) Delete(ctx context.Context, id string) error {
-	path := fmt.Sprintf("%s/%s", projectsLegacyBasePath, id)
+func (s *ProjectsServiceClient) Delete(ctx context.Context, id int) error {
+	path := fmt.Sprintf("%s/%d", projectsLegacyBasePath, id)
 
 	req, err := s.client.newRequest(ctx, "DELETE", path, nil)
 	if err != nil {

--- a/skytap/project.go
+++ b/skytap/project.go
@@ -27,7 +27,7 @@ type ProjectsServiceClient struct {
 
 // Project resource struct definitions
 type Project struct {
-	ID                 *int         `json:"id,omitempty"`
+	ID                 *int         `json:"id,omitempty,string"`
 	Name               *string      `json:"name,omitempty"`
 	Summary            *string      `json:"summary,omitempty"`
 	AutoAddRoleName    *ProjectRole `json:"auto_add_role_name,omitempty"`

--- a/skytap/project_test.go
+++ b/skytap/project_test.go
@@ -46,7 +46,7 @@ func TestCreateProject(t *testing.T) {
 			body, err := ioutil.ReadAll(req.Body)
 			assert.Nil(t, err)
 			assert.JSONEq(t, `{"name":"test-project","summary":"test project"}`, string(body))
-			io.WriteString(rw, `{"id": "12345", "name": "test-project"}`)
+			io.WriteString(rw, `{"id": 12345, "name": "test-project"}`)
 			createPhase = false
 		} else {
 			if req.URL.Path != "/projects/12345" {
@@ -57,8 +57,8 @@ func TestCreateProject(t *testing.T) {
 			}
 			body, err := ioutil.ReadAll(req.Body)
 			assert.Nil(t, err)
-			assert.JSONEq(t, `{"id": "12345","name":"test-project","summary":"test project"}`, string(body))
-			io.WriteString(rw, `{"id": "12345", "name": "test-project", "summary": "test project"}`)
+			assert.JSONEq(t, `{"id": 12345,"name":"test-project","summary":"test project"}`, string(body))
+			io.WriteString(rw, `{"id": 12345, "name": "test-project", "summary": "test project"}`)
 		}
 	}
 
@@ -84,13 +84,13 @@ func TestReadProject(t *testing.T) {
 		if req.Method != "GET" {
 			t.Error("Bad method")
 		}
-		io.WriteString(rw, `{"id": "12345", "name": "test-project", "summary": "test project"}`)
+		io.WriteString(rw, `{"id": 12345, "name": "test-project", "summary": "test project"}`)
 	}
 
-	projectRead, err := skytap.Projects.Get(context.Background(), "12345")
+	projectRead, err := skytap.Projects.Get(context.Background(), 12345)
 
 	assert.Nil(t, err)
-	assert.Equal(t, &Project{ID: strToPtr("12345"), Name: strToPtr("test-project"), Summary: strToPtr("test project")}, projectRead)
+	assert.Equal(t, &Project{ID: intToPtr(12345), Name: strToPtr("test-project"), Summary: strToPtr("test project")}, projectRead)
 }
 
 func TestUpdateProject(t *testing.T) {
@@ -106,19 +106,19 @@ func TestUpdateProject(t *testing.T) {
 		}
 		body, err := ioutil.ReadAll(req.Body)
 		assert.Nil(t, err)
-		assert.JSONEq(t, `{"id": "12345","name":"updated name","summary":"updated summary"}`, string(body))
-		io.WriteString(rw, `{"id": "12345", "name": "updated name", "summary": "updated summary"}`)
+		assert.JSONEq(t, `{"id": 12345,"name":"updated name","summary":"updated summary"}`, string(body))
+		io.WriteString(rw, `{"id": 12345, "name": "updated name", "summary": "updated summary"}`)
 	}
 
 	opts := &Project{
-		ID:      strToPtr("12345"),
+		ID:      intToPtr(12345),
 		Name:    strToPtr("updated name"),
 		Summary: strToPtr("updated summary"),
 	}
 
-	projectUpdate, err := skytap.Projects.Update(context.Background(), "12345", opts)
+	projectUpdate, err := skytap.Projects.Update(context.Background(), 12345, opts)
 
-	expectedResult := &Project{ID: strToPtr("12345"), Name: strToPtr("updated name"), Summary: strToPtr("updated summary")}
+	expectedResult := &Project{ID: intToPtr(12345), Name: strToPtr("updated name"), Summary: strToPtr("updated summary")}
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, projectUpdate)
@@ -137,7 +137,7 @@ func TestDeleteProject(t *testing.T) {
 		}
 	}
 
-	err := skytap.Projects.Delete(context.Background(), "12345")
+	err := skytap.Projects.Delete(context.Background(), 12345)
 	assert.Nil(t, err)
 }
 
@@ -153,7 +153,7 @@ func TestListProjects(t *testing.T) {
 			t.Error("Bad method")
 		}
 		io.WriteString(rw, `[{
-        "id": "12345",
+        "id": 12345,
         "url": "https://cloud.skytap.com/projects/12345",
         "name": "updated name",
         "summary": "updated summary",

--- a/skytap/project_test.go
+++ b/skytap/project_test.go
@@ -46,7 +46,7 @@ func TestCreateProject(t *testing.T) {
 			body, err := ioutil.ReadAll(req.Body)
 			assert.Nil(t, err)
 			assert.JSONEq(t, `{"name":"test-project","summary":"test project"}`, string(body))
-			io.WriteString(rw, `{"id": 12345, "name": "test-project"}`)
+			io.WriteString(rw, `{"id": "12345", "name": "test-project"}`)
 			createPhase = false
 		} else {
 			if req.URL.Path != "/projects/12345" {
@@ -57,8 +57,8 @@ func TestCreateProject(t *testing.T) {
 			}
 			body, err := ioutil.ReadAll(req.Body)
 			assert.Nil(t, err)
-			assert.JSONEq(t, `{"id": 12345,"name":"test-project","summary":"test project"}`, string(body))
-			io.WriteString(rw, `{"id": 12345, "name": "test-project", "summary": "test project"}`)
+			assert.JSONEq(t, `{"id": "12345","name":"test-project","summary":"test project"}`, string(body))
+			io.WriteString(rw, `{"id": "12345", "name": "test-project", "summary": "test project"}`)
 		}
 	}
 
@@ -84,7 +84,7 @@ func TestReadProject(t *testing.T) {
 		if req.Method != "GET" {
 			t.Error("Bad method")
 		}
-		io.WriteString(rw, `{"id": 12345, "name": "test-project", "summary": "test project"}`)
+		io.WriteString(rw, `{"id": "12345", "name": "test-project", "summary": "test project"}`)
 	}
 
 	projectRead, err := skytap.Projects.Get(context.Background(), 12345)
@@ -106,8 +106,8 @@ func TestUpdateProject(t *testing.T) {
 		}
 		body, err := ioutil.ReadAll(req.Body)
 		assert.Nil(t, err)
-		assert.JSONEq(t, `{"id": 12345,"name":"updated name","summary":"updated summary"}`, string(body))
-		io.WriteString(rw, `{"id": 12345, "name": "updated name", "summary": "updated summary"}`)
+		assert.JSONEq(t, `{"id": "12345","name":"updated name","summary":"updated summary"}`, string(body))
+		io.WriteString(rw, `{"id": "12345", "name": "updated name", "summary": "updated summary"}`)
 	}
 
 	opts := &Project{
@@ -153,7 +153,7 @@ func TestListProjects(t *testing.T) {
 			t.Error("Bad method")
 		}
 		io.WriteString(rw, `[{
-        "id": 12345,
+        "id": "12345",
         "url": "https://cloud.skytap.com/projects/12345",
         "name": "updated name",
         "summary": "updated summary",

--- a/skytap/settings_test.go
+++ b/skytap/settings_test.go
@@ -21,17 +21,17 @@ func TestNewDefaultSettingsWithOpts(t *testing.T) {
 	baseURL := "https://url.com"
 	userAgent := "testclient/1.0.0"
 	username := "user"
-	password := "password"
+	token := "token"
 
 	settings := NewDefaultSettings(
 		WithBaseURL(baseURL),
-		WithCredentialsProvider(NewPasswordCredentials(username, password)))
+		WithCredentialsProvider(NewAPITokenCredentials(username, token)))
 
 	assert.Equal(t, baseURL, settings.baseURL)
 	assert.Equal(t, DefaultUserAgent, settings.userAgent)
 
 	if assert.NotNil(t, settings.credentials) {
-		assert.IsType(t, &PasswordCredentials{}, settings.credentials)
+		assert.IsType(t, &APITokenCredentials{}, settings.credentials)
 	}
 
 	settings = NewDefaultSettings(WithUserAgent(userAgent))


### PR DESCRIPTION
The Project ID was previously modelled as a string. The API documents states it as an int. It has been changed to an int.

Please accept and merge the v2 PR first #9.