### PR TITLE
Add retry logic to the SDK

### DIFF
--- a/skytap/client.go
+++ b/skytap/client.go
@@ -22,7 +22,7 @@ const (
 	headerRequestID  = "X-Request-ID"
 	headerRetryAfter = "Retry-After"
 
-	defRetryAfter = 2
+	defRetryAfter = 10
 	defRetryCount = 6
 )
 

--- a/skytap/client_test.go
+++ b/skytap/client_test.go
@@ -1,0 +1,171 @@
+package skytap
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testingRetryAfter = 1
+	testingRetryCount = 3
+)
+
+func createClient(t *testing.T) (*Client, *httptest.Server, *func(rw http.ResponseWriter, req *http.Request)) {
+	handler := http.NotFound
+	hs := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		handler(rw, req)
+	}))
+
+	var user = "SKYTAP_USER"
+	var token = "SKYTAP_ACCESS_TOKEN"
+
+	settings := NewDefaultSettings(WithBaseURL(hs.URL), WithCredentialsProvider(NewAPITokenCredentials(user, token)))
+
+	skytap, err := NewClient(settings)
+	skytap.retryCount = testingRetryCount
+	skytap.retryAfter = testingRetryAfter
+
+	assert.Nil(t, err)
+	assert.NotNil(t, skytap)
+	return skytap, hs, &handler
+}
+
+func TestRetryWithFailure(t *testing.T) {
+	requestCounter := 0
+	skytap, hs, handler := createClient(t)
+
+	defer hs.Close()
+
+	*handler = func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(401)
+		requestCounter++
+	}
+
+	_, err := skytap.Projects.Get(context.Background(), 12345)
+	errorResponse := err.(*ErrorResponse)
+
+	assert.Nil(t, errorResponse.RetryAfter)
+	assert.Equal(t, 1, requestCounter)
+	assert.Equal(t, 401, errorResponse.Response.StatusCode)
+
+}
+
+func TestRetryWithBusy423(t *testing.T) {
+	requestCounter := 0
+	skytap, hs, handler := createClient(t)
+	skytap.retryCount = 1
+	defer hs.Close()
+
+	*handler = func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("Retry-After", "2")
+		rw.WriteHeader(http.StatusLocked)
+		requestCounter++
+	}
+
+	_, err := skytap.Projects.Get(context.Background(), 12345)
+	errorResponse := err.(*ErrorResponse)
+
+	assert.Equal(t, http.StatusLocked, errorResponse.Response.StatusCode)
+	assert.Equal(t, 2, *errorResponse.RetryAfter)
+	assert.True(t, errorResponse.RequiresRetry)
+	assert.Equal(t, 2, requestCounter)
+	assert.Equal(t, 3, testingRetryCount)
+}
+
+func TestRetryWithBusy423WithBadRetryAfter(t *testing.T) {
+	requestCounter := 0
+	skytap, hs, handler := createClient(t)
+	defer hs.Close()
+
+	*handler = func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("Retry-After", "xxx")
+		rw.WriteHeader(http.StatusLocked)
+		requestCounter++
+	}
+
+	_, err := skytap.Projects.Get(context.Background(), 12345)
+	errorResponse := err.(*ErrorResponse)
+
+	assert.Equal(t, testingRetryAfter, *errorResponse.RetryAfter)
+	assert.Equal(t, http.StatusLocked, errorResponse.Response.StatusCode)
+	assert.Equal(t, testingRetryCount+1, requestCounter)
+}
+
+func TestRetryWithBusy423WithoutRetryAfter(t *testing.T) {
+	requestCounter := 0
+	skytap, hs, handler := createClient(t)
+	defer hs.Close()
+
+	*handler = func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusLocked)
+		requestCounter++
+	}
+
+	_, err := skytap.Projects.Get(context.Background(), 12345)
+	errorResponse := err.(*ErrorResponse)
+
+	assert.Equal(t, testingRetryAfter, *errorResponse.RetryAfter)
+	assert.Equal(t, http.StatusLocked, errorResponse.Response.StatusCode)
+	assert.Equal(t, testingRetryCount+1, requestCounter)
+}
+
+func TestRetryWith429(t *testing.T) {
+	requestCounter := 0
+	skytap, hs, handler := createClient(t)
+	defer hs.Close()
+
+	*handler = func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("Retry-After", "1")
+		rw.WriteHeader(http.StatusTooManyRequests)
+		requestCounter++
+	}
+
+	_, err := skytap.Projects.Get(context.Background(), 12345)
+	errorResponse := err.(*ErrorResponse)
+
+	assert.Equal(t, http.StatusTooManyRequests, errorResponse.Response.StatusCode)
+	assert.Equal(t, testingRetryCount+1, requestCounter)
+}
+
+func TestRetryWith50x(t *testing.T) {
+	requestCounter := 0
+	skytap, hs, handler := createClient(t)
+	defer hs.Close()
+
+	*handler = func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("Retry-After", "1")
+		rw.WriteHeader(http.StatusInternalServerError)
+		requestCounter++
+	}
+
+	_, err := skytap.Projects.Get(context.Background(), 12345)
+	errorResponse := err.(*ErrorResponse)
+
+	assert.Equal(t, http.StatusInternalServerError, errorResponse.Response.StatusCode)
+	assert.Equal(t, testingRetryCount+1, requestCounter)
+}
+
+func TestRetryWith50xResolves(t *testing.T) {
+	requestCounter := 0
+	skytap, hs, handler := createClient(t)
+	defer hs.Close()
+
+	*handler = func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("Retry-After", "1")
+		if requestCounter == 3 {
+			io.WriteString(rw, `{"id": "12345", "name": "test-project", "summary": "test project"}`)
+		} else {
+			rw.WriteHeader(http.StatusInternalServerError)
+		}
+		requestCounter++
+	}
+
+	_, err := skytap.Projects.Get(context.Background(), 12345)
+
+	assert.Nil(t, err)
+}

--- a/skytap/client_test.go
+++ b/skytap/client_test.go
@@ -51,7 +51,7 @@ func TestRetryWithFailure(t *testing.T) {
 
 	assert.Nil(t, errorResponse.RetryAfter)
 	assert.Equal(t, 1, requestCounter)
-	assert.Equal(t, 401, errorResponse.Response.StatusCode)
+	assert.Equal(t, http.StatusUnauthorized, errorResponse.Response.StatusCode)
 
 }
 

--- a/skytap/project_test.go
+++ b/skytap/project_test.go
@@ -5,29 +5,10 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func createClient(t *testing.T) (*Client, *httptest.Server, *func(rw http.ResponseWriter, req *http.Request)) {
-	handler := http.NotFound
-	hs := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		handler(rw, req)
-	}))
-
-	var user = "SKYTAP_USER"
-	var token = "SKYTAP_ACCESS_TOKEN"
-
-	settings := NewDefaultSettings(WithBaseURL(hs.URL), WithCredentialsProvider(NewAPITokenCredentials(user, token)))
-
-	skytap, err := NewClient(settings)
-
-	assert.Nil(t, err)
-	assert.NotNil(t, skytap)
-	return skytap, hs, &handler
-}
 
 func TestCreateProject(t *testing.T) {
 	skytap, hs, handler := createClient(t)


### PR DESCRIPTION
Referring to the existing SDK add retry logic to v2 of the SDK.
Every request will have retry logic that:

  1. Checks response for 423, 429 and 5xx and if the response has one of these codes then retry.
  2. otherwise immediately error

The requests will be retries for a given number of times. Each retry will pause for a given amount of time. If a `Retry-After` header is present this will be used.

When it comes to waiting for resources - this is outside the scope of this change. Please refer to issue #20