### PR TITLE
#26 ProjectID missing from update request

### DIFF
--- a/skytap/environment.go
+++ b/skytap/environment.go
@@ -404,6 +404,7 @@ type CreateEnvironmentRequest struct {
 // UpdateEnvironmentRequest describes the update the environment data
 type UpdateEnvironmentRequest struct {
 	Name            *string              `json:"name,omitempty"`
+	ProjectID       *int                 `json:"project_id,omitempty"`
 	Description     *string              `json:"description,omitempty"`
 	Owner           *string              `json:"owner,omitempty"`
 	OutboundTraffic *bool                `json:"outbound_traffic,omitempty"`
@@ -471,6 +472,7 @@ func (s *EnvironmentsServiceClient) Create(ctx context.Context, request *CreateE
 
 	updateOpts := &UpdateEnvironmentRequest{
 		Name:            request.Name,
+		ProjectID:       request.ProjectID,
 		Description:     request.Description,
 		Owner:           request.Owner,
 		OutboundTraffic: request.OutboundTraffic,

--- a/skytap/environment_test.go
+++ b/skytap/environment_test.go
@@ -390,7 +390,7 @@ func TestCreateEnvironment(t *testing.T) {
 			}
 			body, err := ioutil.ReadAll(req.Body)
 			assert.Nil(t, err)
-			assert.JSONEq(t, `{"description": "test environment", "runstate":"running"}`, string(body))
+			assert.JSONEq(t, `{"project_id":12345, "description": "test environment", "runstate":"running"}`, string(body))
 
 			io.WriteString(rw, exampleEnvironment)
 		}


### PR DESCRIPTION
Adding the project id to the update structure. This will allow an existing environment to be added to a project as expected.