### PR TITLE
Add and remove disks

### DIFF
--- a/skytap/client.go
+++ b/skytap/client.go
@@ -203,7 +203,10 @@ func (c *Client) do(ctx context.Context, req *http.Request, v interface{}) (*htt
 		err = c.checkResponse(resp)
 
 		if err == nil {
-			readResponseBody(resp, v)
+			errBody := readResponseBody(resp, v)
+			if errBody != nil {
+				break
+			}
 			makeRequest = false
 		} else if err.(*ErrorResponse).RequiresRetry {
 			seconds := *err.(*ErrorResponse).RetryAfter
@@ -212,7 +215,10 @@ func (c *Client) do(ctx context.Context, req *http.Request, v interface{}) (*htt
 		} else {
 			makeRequest = false
 		}
-		resp.Body.Close()
+		errBody := resp.Body.Close()
+		if errBody != nil {
+			break
+		}
 	}
 
 	return resp, err

--- a/skytap/vm.go
+++ b/skytap/vm.go
@@ -2,6 +2,8 @@ package skytap
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"sort"
 	"time"
 )
@@ -87,6 +89,7 @@ type Disk struct {
 	Type       *string `json:"type"`
 	Controller *string `json:"controller"`
 	LUN        *string `json:"lun"`
+	Name       *string `json:"name,omitempty"`
 }
 
 // Note describes a note on the VM
@@ -189,18 +192,29 @@ type UpdateVMRequest struct {
 
 // UpdateHardware describes the update data to update the VM cpu, ram and disks
 type UpdateHardware struct {
-	CPUs     *int      `json:"cpus,omitempty"`
-	RAM      *int      `json:"ram,omitempty"`
-	NewDisks *NewDisks `json:"disks,omitempty"`
+	CPUs        *int         `json:"cpus,omitempty"`
+	RAM         *int         `json:"ram,omitempty"`
+	UpdateDisks *UpdateDisks `json:"disks,omitempty"`
 }
 
-// NewDisks defines a list of new disks via the sizes
-type NewDisks struct {
-	Sizes []int `json:"new,omitempty"`
+// UpdateDisks defines a list of new disks
+type UpdateDisks struct {
+	NewDisks           []int                 `json:"new,omitempty"`
+	RemoveDisks        map[string]RemoveDisk `json:"existing,omitempty"`
+	DiskIdentification []DiskIdentification  `json:"identification,omitempty"`
+}
+
+// DiskIdentification defines a new size and name combination
+type DiskIdentification struct {
+	ID   *string
+	Size *int
+	Name *string
 }
 
 // RemoveDisk defines the disk to remove
 type RemoveDisk struct {
+	ID   *string `json:"id"`
+	Size *int    `json:"size"`
 }
 
 // VMListResult is the listing request specific struct
@@ -276,32 +290,14 @@ func (s *VMsServiceClient) Create(ctx context.Context, environmentID string, opt
 	return createdVM, nil
 }
 
-// mostRecentVM returns the mose recent VM given a list of VMs
-func mostRecentVM(vms []VM) *VM {
-	sort.Slice(vms, func(i, j int) bool {
-		time1, _ := time.Parse(timestampFormat, *vms[i].CreatedAt)
-		time2, _ := time.Parse(timestampFormat, *vms[j].CreatedAt)
-		return time1.After(time2)
-	})
-	return &vms[0]
-}
-
 // Update a vm
-func (s *VMsServiceClient) Update(ctx context.Context, environmentID string, id string, vm *UpdateVMRequest) (*VM, error) {
-	path := s.buildPath(false, environmentID, id)
-
-	req, err := s.client.newRequest(ctx, "PUT", path, vm)
-	if err != nil {
-		return nil, err
+func (s *VMsServiceClient) Update(ctx context.Context, environmentID string, id string, opts *UpdateVMRequest) (*VM, error) {
+	if opts.Runstate != nil {
+		return s.changeRunstate(ctx, environmentID, id, opts)
+	} else if opts.Hardware != nil && opts.Hardware.UpdateDisks == nil {
+		return s.changeNameCPURAM(ctx, environmentID, id, opts)
 	}
-
-	var updatedVM VM
-	_, err = s.client.do(ctx, req, &updatedVM)
-	if err != nil {
-		return nil, err
-	}
-
-	return &updatedVM, nil
+	return s.updateHardware(ctx, environmentID, id, opts)
 }
 
 // Delete a vm
@@ -321,6 +317,223 @@ func (s *VMsServiceClient) Delete(ctx context.Context, environmentID string, id 
 	return nil
 }
 
+// mostRecentVM returns the mose recent VM given a list of VMs
+func mostRecentVM(vms []VM) *VM {
+	sort.Slice(vms, func(i, j int) bool {
+		time1, _ := time.Parse(timestampFormat, *vms[i].CreatedAt)
+		time2, _ := time.Parse(timestampFormat, *vms[j].CreatedAt)
+		return time1.After(time2)
+	})
+	return &vms[0]
+}
+
+func (s *VMsServiceClient) updateHardware(ctx context.Context, environmentID string, id string, opts *UpdateVMRequest) (*VM, error) {
+	path := s.buildPath(false, environmentID, id)
+
+	diskIdentification := opts.Hardware.UpdateDisks.DiskIdentification
+	opts.Hardware.UpdateDisks.DiskIdentification = nil
+
+	currentVM, err := s.Get(ctx, environmentID, id)
+	// if started stop
+	runstate := currentVM.Runstate
+	if *runstate == VMRunstateRunning {
+		_, err = s.changeRunstate(ctx, environmentID, id, &UpdateVMRequest{Runstate: vmRunStateToPtr(VMRunstateStopped)})
+		err = s.waitForRunstate(&ctx, environmentID, id, VMRunstateStopped)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	removes := buildRemoveList(currentVM, diskIdentification)
+
+	requestCreate, err := s.client.newRequest(ctx, "PUT", path, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var updatedVM VM
+	_, err = s.client.do(ctx, requestCreate, &updatedVM)
+	if err != nil {
+		return nil, err
+	}
+
+	// wait until disks as expected.
+	expected := len(currentVM.Hardware.Disks) + len(opts.Hardware.UpdateDisks.NewDisks)
+	if len(updatedVM.Hardware.Disks) != expected {
+		vm, err := s.waitForDisks(&ctx, environmentID, id, expected)
+		if err != nil {
+			return nil, err
+		}
+		if vm == nil {
+			return nil, fmt.Errorf("unable to retrieve the VM with the expected (%d) number of disks", expected)
+		}
+		updatedVM = *vm
+	}
+
+	matchUpExistingDisks(&updatedVM, diskIdentification, removes)
+	matchUpNewDisks(&updatedVM, diskIdentification, removes)
+
+	disks := updatedVM.Hardware.Disks
+
+	if len(removes) > 0 {
+		// delete phase
+		opts.Hardware.CPUs = nil
+		opts.Hardware.RAM = nil
+		opts.Hardware.UpdateDisks.NewDisks = nil
+		opts.Hardware.UpdateDisks.RemoveDisks = removes
+		requestDelete, err := s.client.newRequest(ctx, "PUT", path, opts)
+		if err != nil {
+			return nil, err
+		}
+		_, err = s.client.do(ctx, requestDelete, &updatedVM)
+		if err != nil {
+			return nil, err
+		}
+
+		// wait until disks as expected.
+		expected = len(disks) - len(opts.Hardware.UpdateDisks.RemoveDisks)
+		if len(updatedVM.Hardware.Disks) != expected {
+			vm, err := s.waitForDisks(&ctx, environmentID, id, expected)
+			if err != nil {
+				return nil, err
+			}
+			if vm == nil {
+				return nil, fmt.Errorf("unable to retrieve the VM with the expected (%d) number of disks", expected)
+			}
+			updatedVM = *vm
+		}
+
+		// update new list of disks
+		updateFinalDiskList(updatedVM, disks)
+	}
+
+	// if stopped start
+	if *runstate == VMRunstateRunning {
+		_, err = s.changeRunstate(ctx, environmentID, id, &UpdateVMRequest{Runstate: vmRunStateToPtr(VMRunstateRunning)})
+		err = s.waitForRunstate(&ctx, environmentID, id, VMRunstateRunning)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &updatedVM, nil
+}
+
+func (s *VMsServiceClient) changeRunstate(ctx context.Context, environmentID string, id string, opts *UpdateVMRequest) (*VM, error) {
+	path := s.buildPath(false, environmentID, id)
+
+	opts.Name = nil
+	opts.Hardware = nil
+	requestCreate, err := s.client.newRequest(ctx, "PUT", path, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var updatedVM VM
+	_, err = s.client.do(ctx, requestCreate, &updatedVM)
+	if err != nil {
+		return nil, err
+	}
+	return &updatedVM, nil
+}
+
+func (s *VMsServiceClient) changeNameCPURAM(ctx context.Context, environmentID string, id string, opts *UpdateVMRequest) (*VM, error) {
+	path := s.buildPath(false, environmentID, id)
+
+	requestCreate, err := s.client.newRequest(ctx, "PUT", path, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var updatedVM VM
+	_, err = s.client.do(ctx, requestCreate, &updatedVM)
+	if err != nil {
+		return nil, err
+	}
+	return &updatedVM, nil
+}
+
+func matchUpExistingDisks(vm *VM, identifications []DiskIdentification, ignored map[string]RemoveDisk) {
+	for idx := range vm.Hardware.Disks {
+		// ignore os disk
+		if idx > 0 {
+			for _, id := range identifications {
+				if id.ID != nil && *id.ID == *vm.Hardware.Disks[idx].ID {
+					_, ignore := ignored[*id.ID]
+					if !ignore {
+						vm.Hardware.Disks[idx].Name = id.Name
+						break
+					}
+				}
+			}
+		}
+	}
+}
+
+func matchUpNewDisks(vm *VM, identifications []DiskIdentification, ignored map[string]RemoveDisk) {
+	for _, id := range identifications {
+		if id.ID == nil {
+			for idx, disk := range vm.Hardware.Disks {
+				// ignore os disk
+				if idx > 0 {
+					// a new disk
+					if _, ok := ignored[*disk.ID]; !ok {
+						if disk.Name == nil {
+							vm.Hardware.Disks[idx].Name = id.Name
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// wait until new disks added
+func (s *VMsServiceClient) waitForDisks(ctx *context.Context, environmentID string, id string, expectedDiskCount int) (*VM, error) {
+	var makeRequest = true
+	var vm *VM
+	var err error
+	for i := 0; i < s.client.retryCount+1 && makeRequest; i++ {
+		vm, err = s.Get(*ctx, environmentID, id)
+
+		if err != nil {
+			break
+		}
+
+		makeRequest = len(vm.Hardware.Disks) != expectedDiskCount
+
+		if makeRequest {
+			seconds := s.client.retryAfter
+			log.Printf("[INFO] retrying after %d second(s)\n", seconds)
+			time.Sleep(time.Duration(seconds) * time.Second)
+		}
+	}
+	return vm, nil
+}
+
+// wait for runstate
+func (s *VMsServiceClient) waitForRunstate(ctx *context.Context, environmentID string, id string, runstate VMRunstate) error {
+	var makeRequest = true
+	var err error
+	for i := 0; i < s.client.retryCount+1 && makeRequest; i++ {
+		vm, err := s.Get(*ctx, environmentID, id)
+
+		if err != nil {
+			break
+		}
+
+		makeRequest = *vm.Runstate != runstate
+
+		if makeRequest {
+			seconds := s.client.retryAfter
+			log.Printf("[INFO] retrying after %d second(s)\n", seconds)
+			time.Sleep(time.Duration(seconds) * time.Second)
+		}
+	}
+	return err
+}
+
 func (s *VMsServiceClient) buildPath(legacy bool, environmentID string, vmID string) string {
 	var path string
 	if legacy {
@@ -333,4 +546,40 @@ func (s *VMsServiceClient) buildPath(legacy bool, environmentID string, vmID str
 		path += vmsPath + vmID
 	}
 	return path
+}
+
+func updateFinalDiskList(vm VM, disks []Disk) {
+	for idx := range vm.Hardware.Disks {
+		// forget os disk
+		if idx > 0 {
+			for _, name := range disks {
+				if *name.ID == *vm.Hardware.Disks[idx].ID {
+					vm.Hardware.Disks[idx].Name = name.Name
+					break
+				}
+			}
+		}
+	}
+}
+
+// clear the removes from this phase
+func buildRemoveList(vm *VM, diskIDs []DiskIdentification) map[string]RemoveDisk {
+	removes := make(map[string]RemoveDisk, 0)
+	for idx, disk := range vm.Hardware.Disks {
+		if idx > 0 {
+			found := false
+			for _, diskID := range diskIDs {
+				if diskID.ID != nil && *diskID.ID == *disk.ID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				removes[*disk.ID] = RemoveDisk{
+					ID: strToPtr(*disk.ID),
+				}
+			}
+		}
+	}
+	return removes
 }

--- a/skytap/vm.go
+++ b/skytap/vm.go
@@ -472,7 +472,7 @@ func matchUpExistingDisks(vm *VM, identifications []DiskIdentification, ignored 
 
 func matchUpNewDisks(vm *VM, identifications []DiskIdentification, ignored map[string]RemoveDisk) {
 	for _, id := range identifications {
-		if id.ID == nil {
+		if id.ID == nil || *id.ID == "" {
 			for idx, disk := range vm.Hardware.Disks {
 				// ignore os disk
 				if idx > 0 {

--- a/skytap/vm.go
+++ b/skytap/vm.go
@@ -459,8 +459,7 @@ func matchUpExistingDisks(vm *VM, identifications []DiskIdentification, ignored 
 		if idx > 0 {
 			for _, id := range identifications {
 				if id.ID != nil && *id.ID == *vm.Hardware.Disks[idx].ID {
-					_, ignore := ignored[*id.ID]
-					if !ignore {
+					if _, ok := ignored[*id.ID]; !ok {
 						vm.Hardware.Disks[idx].Name = id.Name
 						break
 					}

--- a/skytap/vm_test.go
+++ b/skytap/vm_test.go
@@ -78,9 +78,160 @@ func TestUpdateVM(t *testing.T) {
 	skytap, hs, handler := createClient(t)
 	defer hs.Close()
 
+	var vmCurrent VM
+	err := json.Unmarshal([]byte(response), &vmCurrent)
+	assert.NoError(t, err)
+	vmCurrent.Hardware.Disks = vmCurrent.Hardware.Disks[0:3]
+	bytesCurrent, err := json.Marshal(&vmCurrent)
+	assert.Nil(t, err, "Bad vm")
+
+	var vmDisksAdded VM
+	err = json.Unmarshal([]byte(response), &vmDisksAdded)
+	assert.NoError(t, err)
+	vmDisksAdded.Hardware.Disks = vmDisksAdded.Hardware.Disks[0:3]
+	vmDisksAdded.Hardware.Disks = append(vmDisksAdded.Hardware.Disks, *createDisk("disk-20142867-38186761-scsi-0-3", nil))
+	bytesDisksAdded, err := json.Marshal(&vmDisksAdded)
+	assert.Nil(t, err, "Bad vm")
+
+	var vmNew VM
+	err = json.Unmarshal([]byte(response), &vmNew)
+	vmNew.Hardware.Disks = vmNew.Hardware.Disks[0:2]
+	vmNew.Hardware.Disks[1].Name = strToPtr("1")
+	vmNew.Hardware.Disks = append(vmNew.Hardware.Disks, *createDisk("disk-20142867-38186761-scsi-0-3", strToPtr("3")))
+	bytesNew, err := json.Marshal(&vmNew)
+	assert.Nil(t, err, "Bad vm")
+
+	first := true
+	second := true
+	third := true
+	fourth := true
+	fifth := true
+	sixth := true
+	seventh := true
+	*handler = func(rw http.ResponseWriter, req *http.Request) {
+		if first {
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "GET", req.Method, "Bad method")
+
+			_, err := io.WriteString(rw, string(bytesCurrent))
+			assert.NoError(t, err)
+			first = false
+		} else if second {
+			// add the hardware changes
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "PUT", req.Method, "Bad method")
+
+			body, err := ioutil.ReadAll(req.Body)
+			assert.Nil(t, err, "Bad request body")
+			assert.JSONEq(t, `{"name": "updated vm", "hardware" : {"cpus": 12, "ram": 8192, "disks": {"new": [51200]}}}`, string(body), "Bad request body")
+
+			_, err = io.WriteString(rw, string(bytesCurrent))
+			assert.NoError(t, err)
+			second = false
+		} else if third {
+			// does it need a retry block?
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "GET", req.Method, "Bad method")
+
+			_, err := io.WriteString(rw, string(bytesCurrent))
+			assert.NoError(t, err)
+			third = false
+		} else if fourth {
+			// the last retry - gives the expected count (6 currently)
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "GET", req.Method, "Bad method")
+
+			_, err := io.WriteString(rw, string(bytesDisksAdded))
+			assert.NoError(t, err)
+			fourth = false
+		} else if fifth {
+			// delete the disks
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "PUT", req.Method, "Bad method")
+
+			body, err := ioutil.ReadAll(req.Body)
+			assert.Nil(t, err, "Bad request body")
+			assert.JSONEq(t, `{"name": "updated vm", "hardware" : {"disks": {"existing": {"disk-20142867-38186761-scsi-0-2" : {"id":"disk-20142867-38186761-scsi-0-2", "size": null}}}}}`, string(body), "Bad request body")
+
+			_, err = io.WriteString(rw, string(bytesDisksAdded))
+			assert.NoError(t, err)
+			fifth = false
+		} else if sixth {
+			// first retry - still not as expected
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "GET", req.Method, "Bad method")
+
+			_, err := io.WriteString(rw, string(bytesDisksAdded))
+			assert.NoError(t, err)
+			sixth = false
+		} else if seventh {
+			// the last retry - gives the expected count (4 currently)
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "GET", req.Method, "Bad method")
+
+			_, err := io.WriteString(rw, string(bytesNew))
+			assert.NoError(t, err)
+			fourth = false
+		} else {
+			seventh = false
+		}
+	}
+
+	diskIdentification := make([]DiskIdentification, 2)
+	diskIdentification[0] = DiskIdentification{ID: strToPtr("disk-20142867-38186761-scsi-0-1"),
+		Size: intToPtr(51200),
+		Name: strToPtr("1")}
+	diskIdentification[1] = DiskIdentification{ID: nil,
+		Size: intToPtr(51200),
+		Name: strToPtr("3")}
+
+	opts := &UpdateVMRequest{
+		Name: strToPtr("updated vm"),
+		Hardware: &UpdateHardware{
+			CPUs: intToPtr(12),
+			RAM:  intToPtr(8192),
+			UpdateDisks: &UpdateDisks{
+				NewDisks:           []int{51200},
+				DiskIdentification: diskIdentification,
+			},
+		},
+	}
+	vmUpdate, err := skytap.VMs.Update(context.Background(), "123", "456", opts)
+	assert.Nil(t, err, "Bad API method")
+
+	assert.False(t, first)
+	assert.False(t, second)
+	assert.False(t, third)
+	assert.False(t, fourth)
+	assert.False(t, fifth)
+	assert.False(t, sixth)
+	assert.True(t, seventh)
+
+	assert.Equal(t, vmNew, *vmUpdate, "Bad vm")
+
+	disks := vmUpdate.Hardware.Disks
+	assert.Equal(t, 3, len(disks), "disk length")
+
+	assert.Nil(t, disks[0].Name, "os")
+	assert.Equal(t, "1", *disks[1].Name, "disk name")
+	assert.Equal(t, "3", *disks[2].Name, "disk name")
+
+}
+
+// Updating cpu and ram is possible on their own
+func TestUpdateCPURAMVM(t *testing.T) {
+	response := fmt.Sprintf(string(readTestFile(t, "VMResponse.json")), 456)
+
+	skytap, hs, handler := createClient(t)
+	defer hs.Close()
+
 	var vm VM
 	err := json.Unmarshal([]byte(response), &vm)
 	assert.NoError(t, err)
+	*vm.Name = "updated vm"
+	*vm.Hardware.CPUs = 12
+	*vm.Hardware.RAM = 8192
+
 	bytes, err := json.Marshal(&vm)
 	assert.Nil(t, err, "Bad vm")
 
@@ -90,20 +241,17 @@ func TestUpdateVM(t *testing.T) {
 
 		body, err := ioutil.ReadAll(req.Body)
 		assert.Nil(t, err, "Bad request body")
-		assert.JSONEq(t, `{"name": "updated vm", "hardware" : {"cpus": 12, "ram": 8192, "disks": {"new": [51200,51200,51200]}}}`, string(body), "Bad request body")
+		assert.JSONEq(t, `{"name": "updated vm", "hardware" : {"cpus": 12, "ram": 8192}}`, string(body), "Bad request body")
 
 		_, err = io.WriteString(rw, string(bytes))
 		assert.NoError(t, err)
 	}
 
 	opts := &UpdateVMRequest{
-		Name: strToPtr("updated vm"),
+		Name: strToPtr(*vm.Name),
 		Hardware: &UpdateHardware{
-			CPUs: intToPtr(12),
-			RAM:  intToPtr(8192),
-			NewDisks: &NewDisks{
-				Sizes: []int{51200, 51200, 51200},
-			},
+			CPUs: intToPtr(*vm.Hardware.CPUs),
+			RAM:  intToPtr(*vm.Hardware.RAM),
 		},
 	}
 	vmUpdate, err := skytap.VMs.Update(context.Background(), "123", "456", opts)
@@ -195,4 +343,133 @@ func readTestFile(t *testing.T, name string) []byte {
 		t.Fatal(err)
 	}
 	return bytes
+}
+
+func TestBuildListOfDiskSizes(t *testing.T) {
+	removes := make(map[string]RemoveDisk)
+	removes["1"] = RemoveDisk{
+		ID: strToPtr("1"),
+	}
+	removes["2"] = RemoveDisk{
+		ID: strToPtr("2"),
+	}
+	nameSizes := []DiskIdentification{
+		{nil, intToPtr(51200), strToPtr("1")},
+		{nil, intToPtr(51201), strToPtr("2")},
+		{nil, intToPtr(51200), strToPtr("3")},
+	}
+	opts := &UpdateVMRequest{
+		Hardware: &UpdateHardware{
+			UpdateDisks: &UpdateDisks{
+				NewDisks:           []int{51200, 51201, 51200},
+				DiskIdentification: nameSizes,
+				RemoveDisks:        removes,
+			},
+		},
+	}
+
+	sizes := opts.Hardware.UpdateDisks.NewDisks
+	assert.Equal(t, []int{51200, 51201, 51200}, sizes)
+
+	opts.Hardware.UpdateDisks.NewDisks = []int{51200, 51201, 51200}
+	opts.Hardware.UpdateDisks.DiskIdentification = nil
+
+	sizes = opts.Hardware.UpdateDisks.NewDisks
+	assert.Equal(t, []int{51200, 51201, 51200}, sizes)
+}
+
+func TestMatchUpNamesWithExistingDisks(t *testing.T) {
+	response := fmt.Sprintf(string(readTestFile(t, "VMResponse.json")), 456)
+	var vm VM
+	err := json.Unmarshal([]byte(response), &vm)
+	assert.NoError(t, err)
+	currentDisks := vm.Hardware.Disks
+
+	nameSizes := []DiskIdentification{
+		{strToPtr("disk-20142867-38186761-scsi-0-1"), intToPtr(51200), strToPtr("1")},
+		{strToPtr("disk-20142867-38186761-scsi-0-2"), intToPtr(51201), strToPtr("2")},
+		{nil, intToPtr(51200), strToPtr("4")},
+		{strToPtr("disk-20142867-38186761-scsi-0-3"), intToPtr(51200), strToPtr("3")},
+		{nil, intToPtr(51200), strToPtr("5")},
+		{nil, intToPtr(51200), strToPtr("6")},
+	}
+	opts := &UpdateVMRequest{
+		Hardware: &UpdateHardware{
+			UpdateDisks: &UpdateDisks{
+				DiskIdentification: nameSizes,
+			},
+		},
+	}
+
+	matchUpExistingDisks(&vm, opts.Hardware.UpdateDisks.DiskIdentification, nil)
+
+	assert.Nil(t, currentDisks[0].Name, "os")
+	assert.Equal(t, "1", *currentDisks[1].Name, "disk name")
+	assert.Equal(t, "2", *currentDisks[2].Name, "disk name")
+	assert.Equal(t, "3", *currentDisks[3].Name, "disk name")
+}
+
+func TestMatchUpNamesWithNewDisks(t *testing.T) {
+	response := fmt.Sprintf(string(readTestFile(t, "VMResponse.json")), 456)
+	var vm VM
+	err := json.Unmarshal([]byte(response), &vm)
+	assert.NoError(t, err)
+	// add three more
+	vm.Hardware.Disks = append(vm.Hardware.Disks, *createDisk("disk-20142867-38186761-scsi-0-4", strToPtr("4")))
+	vm.Hardware.Disks = append(vm.Hardware.Disks, *createDisk("disk-20142867-38186761-scsi-0-5", strToPtr("5")))
+	vm.Hardware.Disks = append(vm.Hardware.Disks, *createDisk("disk-20142867-38186761-scsi-0-6", strToPtr("6")))
+	allDisks := vm.Hardware.Disks
+
+	nameSizes := []DiskIdentification{
+		{strToPtr("disk-20142867-38186761-scsi-0-1"), intToPtr(51200), strToPtr("1")},
+		{strToPtr("disk-20142867-38186761-scsi-0-2"), intToPtr(51201), strToPtr("2")},
+		{nil, intToPtr(51200), strToPtr("4")},
+		{strToPtr("disk-20142867-38186761-scsi-0-3"), intToPtr(51200), strToPtr("3")},
+		{nil, intToPtr(51200), strToPtr("5")},
+		{nil, intToPtr(51200), strToPtr("6")},
+	}
+	opts := &UpdateVMRequest{
+		Hardware: &UpdateHardware{
+			UpdateDisks: &UpdateDisks{
+				DiskIdentification: nameSizes,
+			},
+		},
+	}
+
+	matchUpExistingDisks(&vm, opts.Hardware.UpdateDisks.DiskIdentification, nil)
+
+	matchUpNewDisks(&vm, opts.Hardware.UpdateDisks.DiskIdentification, nil)
+
+	assert.Equal(t, "4", *allDisks[4].Name, "disk name")
+	assert.Equal(t, "5", *allDisks[5].Name, "disk name")
+	assert.Equal(t, "6", *allDisks[6].Name, "disk name")
+}
+
+func createDisk(id string, name *string) *Disk {
+	return &Disk{
+		ID:         strToPtr(id),
+		Size:       intToPtr(51200),
+		Type:       strToPtr("SCSI"),
+		Controller: strToPtr("0"),
+		LUN:        strToPtr("-1"),
+		Name:       name,
+	}
+}
+
+func TestBuildRemoveList(t *testing.T) {
+	response := fmt.Sprintf(string(readTestFile(t, "VMResponse.json")), 456)
+	var vm VM
+	err := json.Unmarshal([]byte(response), &vm)
+	assert.NoError(t, err)
+
+	// expecting to delete disk-20142867-38186761-scsi-0-3
+	nameSizes := []DiskIdentification{
+		{strToPtr("disk-20142867-38186761-scsi-0-1"), intToPtr(1), strToPtr("old1")},
+		{strToPtr("disk-20142867-38186761-scsi-0-2"), intToPtr(1), strToPtr("old2")},
+		{nil, intToPtr(1), strToPtr("new1")},
+	}
+
+	removes := buildRemoveList(&vm, nameSizes)
+
+	assert.Equal(t, RemoveDisk{ID: strToPtr("disk-20142867-38186761-scsi-0-3")}, removes["disk-20142867-38186761-scsi-0-3"])
 }


### PR DESCRIPTION
Modify update method to accept disks.
Build list of disks to remove.
Stop a running vm if necessary.
Marry up input name with disks and enrich structure for output.