### PR TITLE
Add fix for routable change

### DIFF
--- a/skytap/environment.go
+++ b/skytap/environment.go
@@ -365,7 +365,7 @@ func (payload *UpdateEnvironmentRequest) string() string {
 	description := ""
 	owner := ""
 	outboundTraffic := ""
-	routable := ""
+	routable := "false"
 	suspendOnIdle := ""
 	suspendAtTime := ""
 	shutdownOnIdle := ""


### PR DESCRIPTION
It is necessary to default to a false for the routable attribute in order for the terraform provider to work. The terraform provider will always send a false for routable even when it isn't set. 