### PR TITLE
Fixing kernel panic when a VM is being modified

### DIFF
--- a/skytap/vm.go
+++ b/skytap/vm.go
@@ -398,6 +398,17 @@ func mostRecentVM(environment *Environment) (*VM, error) {
 	return &vms[0], nil
 }
 
+// updateHardware will update the VM to the specified hardware settings provided in the opts struct.
+//
+// This function proceed in the following order:
+// 1. Stop the VM if running
+// 2. Create and Update (resize) disks and VM settings. This is only executed if there are changes to be made
+// 3. Remove disks from the VM
+// 4. Restart the VM if it was previously running
+//
+// The result will be the new VM struct with the new hardware
+//
+// Important to note is that this function will change the opts passed in
 func (s *VMsServiceClient) updateHardware(ctx context.Context, environmentID string, id string, opts *UpdateVMRequest) (*VM, error) {
 	path := s.buildPath(false, environmentID, id)
 
@@ -410,7 +421,7 @@ func (s *VMsServiceClient) updateHardware(ctx context.Context, environmentID str
 	if err != nil {
 		return nil, err
 	}
-	// if started stop
+	// if VM is started, then we stop it
 	runstate := *vm.Runstate
 	if runstate == VMRunstateRunning {
 		_, err = s.changeRunstate(ctx, environmentID, id, &UpdateVMRequest{Runstate: vmRunStateToPtr(VMRunstateStopped)})
@@ -430,6 +441,8 @@ func (s *VMsServiceClient) updateHardware(ctx context.Context, environmentID str
 
 	state := vmRequestRunStateStopped(environmentID, id)
 	state.diskIdentification = diskIdentification
+
+	// Let's first create new disks, update the current ones or change VM settings
 	if opts.Hardware.UpdateDisks != nil || opts.Hardware.RAM != nil || opts.Hardware.CPUs != nil || opts.Name != nil {
 		requestCreate, err := s.client.newRequest(ctx, "PUT", path, opts)
 		if err != nil {
@@ -445,37 +458,22 @@ func (s *VMsServiceClient) updateHardware(ctx context.Context, environmentID str
 			return nil, err
 		}
 	}
+	// Update VM struct to have the correct disk name
 	matchUpExistingDisks(vm, diskIdentification, removes)
 	matchUpNewDisks(vm, diskIdentification, removes)
 
 	disks := vm.Hardware.Disks
 
 	if len(removes) > 0 {
-		// delete phase
-		opts.Hardware.CPUs = nil
-		opts.Hardware.RAM = nil
-		if opts.Hardware.UpdateDisks == nil {
-			opts.Hardware.UpdateDisks = &UpdateDisks{}
-		}
-		opts.Hardware.UpdateDisks.NewDisks = nil
-		opts.Hardware.UpdateDisks.ExistingDisks = removes
-		requestDelete, err := s.client.newRequest(ctx, "PUT", path, opts)
-		if err != nil {
-			return nil, err
-		}
-		_, err = s.client.do(ctx, requestDelete, &vm, state, opts)
-		if err != nil {
-			return nil, err
-		}
-
-		vm, err = s.Get(ctx, environmentID, id)
+		// delete disk phase, removing all disks only (no other updates to the VM will be performed)
+		vm, err := s.removeDisks(removes, ctx, path, vm, state, environmentID, id)
 		if err != nil {
 			return nil, err
 		}
 		updateFinalDiskList(vm, disks)
 	}
 
-	// if stopped start
+	// if VM was previously running, then we start it again
 	if runstate == VMRunstateRunning {
 		_, err = s.changeRunstate(ctx, environmentID, id, &UpdateVMRequest{Runstate: vmRunStateToPtr(VMRunstateRunning)})
 		if err != nil {
@@ -488,6 +486,30 @@ func (s *VMsServiceClient) updateHardware(ctx context.Context, environmentID str
 		updateFinalDiskList(vm, disks)
 	}
 
+	return vm, nil
+}
+
+func (s *VMsServiceClient) removeDisks(removes map[string]ExistingDisk, ctx context.Context, path string, vm *VM, state *environmentVMRunState, environmentID string, id string) (*VM, error) {
+	removeReq := &UpdateVMRequest{
+		Hardware: &UpdateHardware{
+			UpdateDisks: &UpdateDisks{
+				ExistingDisks: removes,
+			},
+		},
+	}
+	requestDelete, err := s.client.newRequest(ctx, "PUT", path, removeReq)
+	if err != nil {
+		return nil, err
+	}
+	_, err = s.client.do(ctx, requestDelete, &vm, state, removeReq)
+	if err != nil {
+		return nil, err
+	}
+
+	vm, err = s.Get(ctx, environmentID, id)
+	if err != nil {
+		return nil, err
+	}
 	return vm, nil
 }
 
@@ -509,6 +531,7 @@ func (s *VMsServiceClient) changeRunstate(ctx context.Context, environmentID str
 	return &updatedVM, nil
 }
 
+// matchUpNewDisks updates the VM disk names (ignoring the OS disk, that is, the first disk) for all the disk identifications
 func matchUpExistingDisks(vm *VM, identifications []DiskIdentification, ignored map[string]ExistingDisk) {
 	for idx := range vm.Hardware.Disks {
 		// ignore os disk
@@ -525,6 +548,7 @@ func matchUpExistingDisks(vm *VM, identifications []DiskIdentification, ignored 
 	}
 }
 
+// matchUpNewDisks updates the VM disk names for all the disk identifications that had no ID
 func matchUpNewDisks(vm *VM, identifications []DiskIdentification, ignored map[string]ExistingDisk) {
 	for _, id := range identifications {
 		if id.ID == nil || *id.ID == "" {
@@ -572,6 +596,7 @@ func updateFinalDiskList(vm *VM, disks []Disk) {
 	}
 }
 
+// buildRemoveList creates a list of disks containing the disks from the vm that are not longer referenced in the diskIDs
 func buildRemoveList(vm *VM, diskIDs []DiskIdentification) map[string]ExistingDisk {
 	removes := make(map[string]ExistingDisk, 0)
 	for idx, disk := range vm.Hardware.Disks {
@@ -584,6 +609,7 @@ func buildRemoveList(vm *VM, diskIDs []DiskIdentification) map[string]ExistingDi
 				}
 			}
 			if !found {
+				// Not setting the Size on ExistingDisk will cause the disk to be removed
 				removes[*disk.ID] = ExistingDisk{
 					ID: strToPtr(*disk.ID),
 				}
@@ -593,6 +619,7 @@ func buildRemoveList(vm *VM, diskIDs []DiskIdentification) map[string]ExistingDi
 	return removes
 }
 
+// buildUpdateList creates a list of disks containing all the disks that still referenced in the VM but their size has changed
 func buildUpdateList(vm *VM, diskIDs []DiskIdentification) map[string]ExistingDisk {
 	updates := make(map[string]ExistingDisk, 0)
 	for idx, disk := range vm.Hardware.Disks {
@@ -615,6 +642,7 @@ func buildUpdateList(vm *VM, diskIDs []DiskIdentification) map[string]ExistingDi
 	return updates
 }
 
+// addOSDiskResize changes the size of the first disk (assuming that is the OS disk) in the updates map to the osDiskSize
 func addOSDiskResize(osDiskSize *int, vm *VM, updates map[string]ExistingDisk) {
 	if osDiskSize != nil && (*vm.Hardware.Disks[0].Size) < *osDiskSize {
 		updates[*vm.Hardware.Disks[0].ID] = ExistingDisk{
@@ -677,7 +705,7 @@ func (payload *UpdateVMRequest) buildComparison(vm *VM, diskIdentification []Dis
 		}
 	}
 	if payload.Hardware.CPUs == nil && payload.Hardware.RAM == nil && payload.Hardware.UpdateDisks == nil {
-		payload.Hardware = nil
+		update.Hardware = nil
 	}
 	return update
 }

--- a/skytap/vm_test.go
+++ b/skytap/vm_test.go
@@ -259,7 +259,7 @@ func TestUpdateVMModifyDisks(t *testing.T) {
 	assert.Nil(t, disks[0].Name, "os")
 }
 
-func TestUpdateVMModifyAndDeleteDisks(t *testing.T) {
+func TestUpdateVMModifyVMPropertiesAndDeleteDisks(t *testing.T) {
 	response := fmt.Sprintf(string(readTestFile(t, "VMResponse.json")), 456)
 
 	skytap, hs, handler := createClient(t)
@@ -273,6 +273,7 @@ func TestUpdateVMModifyAndDeleteDisks(t *testing.T) {
 
 	var vmModified VM
 	err = json.Unmarshal([]byte(response), &vmModified)
+	vmModified.Name = strToPtr("new vm name")
 	bytesVmModified, err := json.Marshal(&vmModified)
 	assert.Nil(t, err, "Bad vm")
 
@@ -306,7 +307,7 @@ func TestUpdateVMModifyAndDeleteDisks(t *testing.T) {
 			assert.Nil(t, err, "Bad request body")
 			assert.JSONEq(t, `
 				{
-					"name":"test vm",
+					"name":"new vm name",
 					"hardware": {}
 				}`, string(body), "Bad request body")
 
@@ -367,17 +368,133 @@ func TestUpdateVMModifyAndDeleteDisks(t *testing.T) {
 		requestCounter++
 	}
 
-	opts := createVMUpdateStructure()
-	opts.Runstate = nil
-	opts.Hardware.RAM = nil
-	opts.Hardware.CPUs = nil
-	opts.Hardware.UpdateDisks.NewDisks = nil
-	opts.Hardware.UpdateDisks.OSSize = nil
-	opts.Hardware.UpdateDisks.DiskIdentification = opts.Hardware.UpdateDisks.DiskIdentification[0:1]
-	opts.Hardware.UpdateDisks.DiskIdentification[0].Size = intToPtr(51200)
-	delete(opts.Hardware.UpdateDisks.ExistingDisks, "disk-20142867-38186761-scsi-0-1")
-	delete(opts.Hardware.UpdateDisks.ExistingDisks, "disk-20142867-38186761-scsi-0-2")
-	delete(opts.Hardware.UpdateDisks.ExistingDisks, "disk-20142867-38186761-scsi-0-3")
+	opts := createVMUpdateChangingVMNameAndRemovingThreeDisks()
+
+	vmUpdate, err := skytap.VMs.Update(context.Background(), "123", "456", opts)
+	assert.Nil(t, err, "Bad API method")
+
+	assert.Equal(t, 9, requestCounter)
+
+	vmDisksRemoved.Hardware.Disks[1].Name = strToPtr("1")
+	assert.Equal(t, vmDisksRemoved, *vmUpdate, "Bad vm")
+
+	disks := vmUpdate.Hardware.Disks
+	assert.Equal(t, 2, len(disks), "disk length")
+}
+
+func TestUpdateVMAddAndDeleteDisks(t *testing.T) {
+	response := fmt.Sprintf(string(readTestFile(t, "VMResponse.json")), 456)
+
+	skytap, hs, handler := createClient(t)
+	defer hs.Close()
+
+	var vmCurrent VM
+	err := json.Unmarshal([]byte(response), &vmCurrent)
+	assert.NoError(t, err)
+	bytesCurrent, err := json.Marshal(&vmCurrent)
+	assert.Nil(t, err, "Bad vm")
+
+	var vmModified VM
+	err = json.Unmarshal([]byte(response), &vmModified)
+	vmModified.Hardware.Disks = append(vmModified.Hardware.Disks, *createDiskWithSize("disk-20142867-38186761-scsi-0-4", nil, 2048))
+	bytesVmModified, err := json.Marshal(&vmModified)
+	assert.Nil(t, err, "Bad vm")
+
+	var vmDisksRemoved VM
+	err = json.Unmarshal([]byte(response), &vmDisksRemoved)
+	vmDisksRemoved.Hardware.Disks = vmDisksRemoved.Hardware.Disks[0:2]
+	bytesDisksModified, err := json.Marshal(&vmDisksRemoved)
+	assert.Nil(t, err, "Bad vm")
+
+	requestCounter := 0
+	*handler = func(rw http.ResponseWriter, req *http.Request) {
+		log.Printf("Request: (%d)\n", requestCounter)
+		if requestCounter == 0 {
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "GET", req.Method, "Bad method")
+
+			_, err := io.WriteString(rw, string(bytesCurrent))
+			assert.NoError(t, err)
+		} else if requestCounter == 1 {
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "GET", req.Method, "Bad method")
+
+			_, err := io.WriteString(rw, string(bytesCurrent))
+			assert.NoError(t, err)
+		} else if requestCounter == 2 {
+			// delete the disks
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "PUT", req.Method, "Bad method")
+
+			body, err := ioutil.ReadAll(req.Body)
+			assert.Nil(t, err, "Bad request body")
+			assert.JSONEq(t, `
+				{
+					"hardware": {
+						"disks": {
+    						"new": [2048]
+						}
+					}
+				}`, string(body), "Bad request body")
+
+			_, err = io.WriteString(rw, string(bytesVmModified))
+			assert.NoError(t, err)
+		} else if requestCounter == 3 {
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "GET", req.Method, "Bad method")
+
+			_, err := io.WriteString(rw, string(bytesVmModified))
+			assert.NoError(t, err)
+		} else if requestCounter == 4 {
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "GET", req.Method, "Bad method")
+
+			_, err := io.WriteString(rw, string(bytesVmModified))
+			assert.NoError(t, err)
+		} else if requestCounter == 5 {
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "GET", req.Method, "Bad method")
+
+			_, err := io.WriteString(rw, string(bytesVmModified))
+			assert.NoError(t, err)
+		} else if requestCounter == 6 {
+			// delete the disks
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "PUT", req.Method, "Bad method")
+
+			body, err := ioutil.ReadAll(req.Body)
+			assert.Nil(t, err, "Bad request body")
+			assert.JSONEq(t, `
+				{
+					"hardware" : {
+						"disks": {
+							"existing": {
+								"disk-20142867-38186761-scsi-0-2" : {"id":"disk-20142867-38186761-scsi-0-2", "size": null},
+								"disk-20142867-38186761-scsi-0-3" : {"id":"disk-20142867-38186761-scsi-0-3", "size": null}
+							}
+						}
+					}
+				}`, string(body), "Bad request body")
+
+			_, err = io.WriteString(rw, string(bytesDisksModified))
+			assert.NoError(t, err)
+		} else if requestCounter == 7 {
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "GET", req.Method, "Bad method")
+
+			_, err := io.WriteString(rw, string(bytesDisksModified))
+			assert.NoError(t, err)
+		} else if requestCounter == 8 {
+			assert.Equal(t, "/v2/configurations/123/vms/456", req.URL.Path, "Bad path")
+			assert.Equal(t, "GET", req.Method, "Bad method")
+
+			_, err := io.WriteString(rw, string(bytesDisksModified))
+			assert.NoError(t, err)
+		}
+		requestCounter++
+	}
+
+	opts := createVMUpdateRemovingTwoDisksAndAddingOne(2048)
 	vmUpdate, err := skytap.VMs.Update(context.Background(), "123", "456", opts)
 	assert.Nil(t, err, "Bad API method")
 
@@ -883,6 +1000,17 @@ func createDisk(id string, name *string) *Disk {
 	}
 }
 
+func createDiskWithSize(id string, name *string, size int) *Disk {
+	return &Disk{
+		ID:         strToPtr(id),
+		Size:       intToPtr(size),
+		Type:       strToPtr("SCSI"),
+		Controller: strToPtr("0"),
+		LUN:        strToPtr("-1"),
+		Name:       name,
+	}
+}
+
 func TestBuildRemoveList(t *testing.T) {
 	response := fmt.Sprintf(string(readTestFile(t, "VMResponse.json")), 456)
 	var vm VM
@@ -1241,6 +1369,46 @@ func createVMUpdateStructure() *UpdateVMRequest {
 				ExistingDisks:      existingDisks,
 				DiskIdentification: diskIdentification,
 				OSSize:             intToPtr(51201),
+			},
+		},
+	}
+	return opts
+}
+
+// createVMUpdateChangingVMNameAndRemovingThreeDisks creates an UpdateVMRequest will remove 2 disks specified on VMResponse.json
+// and update the VM name (without modifying any disks)
+func createVMUpdateChangingVMNameAndRemovingThreeDisks() *UpdateVMRequest {
+	diskIdentification := make([]DiskIdentification, 1)
+	diskIdentification[0] = DiskIdentification{ID: strToPtr("disk-20142867-38186761-scsi-0-1"),
+		Size: intToPtr(51200),
+		Name: strToPtr("1")}
+
+	existingDisks := make(map[string]ExistingDisk)
+	opts := &UpdateVMRequest{
+		Name: strToPtr("new vm name"),
+		Hardware: &UpdateHardware{
+			UpdateDisks: &UpdateDisks{
+				ExistingDisks:      existingDisks,
+				DiskIdentification: diskIdentification,
+			},
+		},
+	}
+	return opts
+}
+
+// createVMUpdateRemovingTwoDisksAndAddingOne creates an UpdateVMRequest will remove 2 disks specified on VMResponse.json
+// and add one extra disk
+func createVMUpdateRemovingTwoDisksAndAddingOne(newDiskSize int) *UpdateVMRequest {
+	diskIdentification := make([]DiskIdentification, 1)
+	diskIdentification[0] = DiskIdentification{ID: strToPtr("disk-20142867-38186761-scsi-0-1"),
+		Size: intToPtr(51200),
+		Name: strToPtr("1")}
+
+	opts := &UpdateVMRequest{
+		Hardware: &UpdateHardware{
+			UpdateDisks: &UpdateDisks{
+				NewDisks:           []int{newDiskSize},
+				DiskIdentification: diskIdentification,
 			},
 		},
 	}

--- a/skytap/vm_test.go
+++ b/skytap/vm_test.go
@@ -368,7 +368,7 @@ func TestUpdateVMModifyVMPropertiesAndDeleteDisks(t *testing.T) {
 		requestCounter++
 	}
 
-	opts := createVMUpdateChangingVMNameAndRemovingThreeDisks()
+	opts := createVMUpdateChangingVMNameAndRemovingTwoDisks()
 
 	vmUpdate, err := skytap.VMs.Update(context.Background(), "123", "456", opts)
 	assert.Nil(t, err, "Bad API method")
@@ -1375,9 +1375,9 @@ func createVMUpdateStructure() *UpdateVMRequest {
 	return opts
 }
 
-// createVMUpdateChangingVMNameAndRemovingThreeDisks creates an UpdateVMRequest will remove 2 disks specified on VMResponse.json
-// and update the VM name (without modifying any disks)
-func createVMUpdateChangingVMNameAndRemovingThreeDisks() *UpdateVMRequest {
+// createVMUpdateChangingVMNameAndRemovingTwoDisks creates an UpdateVMRequest will remove 2 of the disks specified on
+// VMResponse.json and update the VM name
+func createVMUpdateChangingVMNameAndRemovingTwoDisks() *UpdateVMRequest {
 	diskIdentification := make([]DiskIdentification, 1)
 	diskIdentification[0] = DiskIdentification{ID: strToPtr("disk-20142867-38186761-scsi-0-1"),
 		Size: intToPtr(51200),


### PR DESCRIPTION
* Fixing kernel panic when a VM is being modified (e.g name is changing) while disks need to be removed. 

* Adding comments to the code to help explain what is the desired behaviour of the updateHardware()

* Fixing disk issue which was causing the sdk to wait for the wrong condition.

  When a new disk was added and other disks where removed at the same time, the sdk was   considering the removed disks as new disks. The consequence of this was that the payload comparision ( UpdateVMRequest.compareResponse() ) would never converge to the desired state making the sdk retry until timeout is reached.

