### PR TITLE
Support adding/removing environments to projects

### DIFF
--- a/skytap/environment.go
+++ b/skytap/environment.go
@@ -25,6 +25,7 @@ type EnvironmentsService interface {
 	CreateLabels(ctx context.Context, id string, createLabelRequest []*CreateLabelRequest) error
 	DeleteLabel(ctx context.Context, id string, labelId string) error
 	UpdateUserData(ctx context.Context, id string, userData *string) error
+	ListProjects(ctx context.Context, id string) (*ProjectListResult, error)
 }
 
 // EnvironmentsServiceClient is the EnvironmentsService implementation
@@ -457,6 +458,28 @@ func (s *EnvironmentsServiceClient) UpdateUserData(ctx context.Context, id strin
 	}
 
 	return nil
+}
+
+func (s *EnvironmentsServiceClient) ListProjects(ctx context.Context, id string) (*ProjectListResult, error) {
+	path := fmt.Sprintf("%s/%s/projects", environmentBasePath, id)
+
+	req, err := s.client.newRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.client.setRequestListParameters(req, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var projectListResponse ProjectListResult
+	_, err = s.client.do(ctx, req, &projectListResponse.Value, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &projectListResponse, nil
 }
 
 func (payload *CreateEnvironmentRequest) compareResponse(ctx context.Context, c *Client, v interface{}, state *environmentVMRunState) (string, bool) {

--- a/skytap/project_test.go
+++ b/skytap/project_test.go
@@ -162,3 +162,203 @@ func TestListProjects(t *testing.T) {
 
 	assert.True(t, found)
 }
+
+func TestListEnvironmentsInProject(t *testing.T) {
+	skytap, hs, handler := createClient(t)
+	defer hs.Close()
+
+	*handler = func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/v2/projects/12345/configurations" {
+			t.Error("Bad path:", req.URL.Path)
+		}
+		if req.Method != "GET" {
+			t.Error("Bad method")
+		}
+		_, err := io.WriteString(rw, `[{
+		"id": "6789",
+		"url": "https://cloud.skytap.com/v2/configurations/6789",
+		"name": "tftest-vm-environment-1930588755153240024",
+		"description": "This is an environment to support a vm skytap terraform provider acceptance test",
+		"errors": [],
+		"error_details": [],
+		"runstate": "busy",
+		"rate_limited": false,
+		"last_run": "2021/05/14 10:46:33 +0100",
+		"suspend_on_idle": null,
+		"suspend_at_time": null,
+		"owner_url": "https://cloud.skytap.com/v2/users/468583",
+		"owner_name": "Gary Digby",
+		"owner_id": "468583",
+		"vm_count": 1,
+		"licensed_vm_count": 0,
+		"storage": 30720,
+		"network_count": 2,
+		"created_at": "2021/05/14 10:31:55 +0100",
+		"region": "US-West",
+		"region_backend": "skytap",
+		"svms": 1,
+		"can_save_as_template": true,
+		"can_copy": true,
+		"can_delete": true,
+		"can_change_state": true,
+		"can_share": true,
+		"can_edit": true,
+		"label_count": 0,
+		"label_category_count": 0,
+		"can_tag": true,
+		"can_change_owner": true,
+		"tag_list": "",
+		"alerts": [],
+		"vms": [
+			{
+				"id": "4859384",
+				"url": "https://cloud.skytap.com/v2/vms/4859384",
+				"name": "cassandra1",
+				"runstate": "running",
+				"rate_limited": false,
+				"error": null,
+				"status": "running",
+				"hardware": {
+					"cpus": 1,
+					"ram": 1024,
+					"svms": 1,
+					"storage": 30720,
+					"guestOS": "centos-64",
+					"architecture": "x86"
+				},
+				"license_types": [],
+				"region_backend": "skytap",
+				"supports_suspend": true,
+				"environment_locked": false
+			}
+		],
+		"container_hosts_count": 0,
+		"platform_errors": [],
+		"svms_by_architecture": {
+			"x86": 1,
+			"power": 0
+		},
+		"all_vms_support_suspend": true,
+		"shutdown_on_idle": null,
+		"shutdown_at_time": null,
+		"environment_locked": false,
+		"can_lock": true,
+		"environment_lock": null
+		}]`)
+		assert.NoError(t, err)
+	}
+
+	result, err := skytap.Projects.ListEnvironments(context.Background(), 12345)
+	assert.NoError(t, err)
+
+	assert.Len(t, result.Value, 1)
+	assert.Equal(t, "6789", result.Value[0].ID)
+}
+
+func TestAddEnvironmentToProject(t *testing.T) {
+	skytap, hs, handler := createClient(t)
+	defer hs.Close()
+
+	*handler = func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/v2/projects/12345/configurations/6789" {
+			t.Error("Bad path:", req.URL.Path)
+		}
+		if req.Method != "POST" {
+			t.Error("Bad method")
+		}
+		_, err := io.WriteString(rw, `{
+		"id": "6789",
+		"url": "https://cloud.skytap.com/v2/configurations/6789",
+		"name": "tftest-vm-environment-1930588755153240024",
+		"description": "This is an environment to support a vm skytap terraform provider acceptance test",
+		"errors": [],
+		"error_details": [],
+		"runstate": "busy",
+		"rate_limited": false,
+		"last_run": "2021/05/14 10:46:33 +0100",
+		"suspend_on_idle": null,
+		"suspend_at_time": null,
+		"owner_url": "https://cloud.skytap.com/v2/users/468583",
+		"owner_name": "Gary Digby",
+		"owner_id": "468583",
+		"vm_count": 1,
+		"licensed_vm_count": 0,
+		"storage": 30720,
+		"network_count": 2,
+		"created_at": "2021/05/14 10:31:55 +0100",
+		"region": "US-West",
+		"region_backend": "skytap",
+		"svms": 1,
+		"can_save_as_template": true,
+		"can_copy": true,
+		"can_delete": true,
+		"can_change_state": true,
+		"can_share": true,
+		"can_edit": true,
+		"label_count": 0,
+		"label_category_count": 0,
+		"can_tag": true,
+		"can_change_owner": true,
+		"tag_list": "",
+		"alerts": [],
+		"vms": [
+			{
+				"id": "4859384",
+				"url": "https://cloud.skytap.com/v2/vms/4859384",
+				"name": "cassandra1",
+				"runstate": "running",
+				"rate_limited": false,
+				"error": null,
+				"status": "running",
+				"hardware": {
+					"cpus": 1,
+					"ram": 1024,
+					"svms": 1,
+					"storage": 30720,
+					"guestOS": "centos-64",
+					"architecture": "x86"
+				},
+				"license_types": [],
+				"region_backend": "skytap",
+				"supports_suspend": true,
+				"environment_locked": false
+			}
+		],
+		"container_hosts_count": 0,
+		"platform_errors": [],
+		"svms_by_architecture": {
+			"x86": 1,
+			"power": 0
+		},
+		"all_vms_support_suspend": true,
+		"shutdown_on_idle": null,
+		"shutdown_at_time": null,
+		"environment_locked": false,
+		"can_lock": true,
+		"environment_lock": null
+	}`)
+		assert.NoError(t, err)
+	}
+
+	env, err := skytap.Projects.AddEnvironment(context.Background(), 12345, "6789")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "6789", env.ID)
+}
+
+func TestRemoveEnvironmentFromProject(t *testing.T) {
+	skytap, hs, handler := createClient(t)
+	defer hs.Close()
+
+	*handler = func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/v2/projects/12345/configurations/6789" {
+			t.Error("Bad path:", req.URL.Path)
+		}
+		if req.Method != "DELETE" {
+			t.Error("Bad method")
+		}
+	}
+
+	err := skytap.Projects.RemoveEnvironment(context.Background(), 12345, "6789")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This PR adds 4 new methods: 

- For the project service, `ListEnvironments`, `AddEnvironment`, `RemoveEnvironment` 
- For the environment service, `ListProjects`

This is to support the Terraform provider in adding environments to projects.

A new `ProjectEnvironment` type is added with a single `ID` field, because the existing `Environment` type is subtly different from the environment returned in the new API calls, so I didn't think it made sense to try and reuse it. If more information on the environments are needed, then the returned IDs can be used for separate lookups for now.